### PR TITLE
Allow for ignoring certain fields in saved request body

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -31,6 +31,7 @@ dependencies:
 - http-types
 - bytestring
 - bytestring-builder
+- unordered-containers
 - text
 - directory
 - case-insensitive

--- a/src/Network/VCR.hs
+++ b/src/Network/VCR.hs
@@ -28,12 +28,12 @@ import qualified Network.Wai.Handler.Warp   as Warp
 import           Control.Applicative        ((<**>))
 import           Network.VCR.Middleware     (die, middleware)
 import           Network.VCR.Types          (Cassette, Mode (..), Options (..),
-                                             emptyCassette, parseOptions)
+                                             emptyCassette, parseOptions, readCassette)
 import           Options.Applicative        (execParser, fullDesc, header,
                                              helper, info, progDesc)
 import           System.Environment         (getArgs)
 
-import           Data.Yaml                  (decodeFileEither, encodeFile)
+import           Data.Yaml                  (encodeFile)
 import           System.Directory           (doesFileExist)
 import           System.IO                  (BufferMode (..), hSetBuffering,
                                              stdout)
@@ -55,7 +55,7 @@ run options@Options { mode, cassettePath, port } = do
       exists <- doesFileExist cassettePath
       when (not exists) $ encodeFile cassettePath (emptyCassette $ T.pack endpoint)
     _ -> pure ()
-  cas <- decodeFileEither cassettePath
+  cas <- readCassette cassettePath
   case cas of
     Left  err -> die $ "Cassette: " <> cassettePath <> " couldn't be decoded or found! " <> (show err)
     Right cassette -> do

--- a/src/Network/VCR/Types.hs
+++ b/src/Network/VCR/Types.hs
@@ -1,18 +1,25 @@
-{-# LANGUAGE DeriveAnyClass  #-}
-{-# LANGUAGE DeriveGeneric   #-}
-{-# LANGUAGE NamedFieldPuns  #-}
-{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE DeriveAnyClass      #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE PatternSynonyms     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 module Network.VCR.Types where
 
 import qualified Data.ByteString         as B
 import qualified Data.ByteString.Lazy    as L
+import           Data.HashMap.Strict     (HashMap)
+import qualified Data.HashMap.Strict     as HashMap
+import           Data.Maybe              (fromJust)
 import           Data.Text               (Text)
 import qualified Data.Text.Encoding      as BE (decodeUtf8, encodeUtf8)
 import qualified Data.Text.Lazy.Encoding as BEL (decodeUtf8, encodeUtf8)
+import           Data.Yaml               (ParseException, decodeFileEither)
 
 
 import           Control.Monad           (mzero)
+import qualified Data.Aeson.Types        as JSON
 import           Data.Aeson              (FromJSON, ToJSON, Value (..), object,
+                                          decode, encode,
                                           parseJSON, toJSON, (.:), (.=))
 import           Data.CaseInsensitive    (foldedCase, mk)
 import           GHC.Generics            (Generic)
@@ -72,9 +79,10 @@ data ApiCall = ApiCall
   } deriving (Show, Eq, Generic, ToJSON, FromJSON)
 
 data Cassette = Cassette
-  { endpoint       :: Text
-  , apiCalls       :: [ApiCall]
-  , ignoredHeaders :: [Text]
+  { endpoint          :: Text
+  , apiCalls          :: [ApiCall]
+  , ignoredHeaders    :: [Text]
+  , ignoredBodyFields :: [Text]
   } deriving (Show, Eq, Generic, ToJSON, FromJSON)
 
 
@@ -140,5 +148,28 @@ toHeader (name, value)  =  (mk $ BE.encodeUtf8 name, BE.encodeUtf8 value)
 
 
 emptyCassette :: Text -> Cassette
-emptyCassette endpoint = Cassette { endpoint = endpoint, apiCalls = [], ignoredHeaders = [] }
+emptyCassette endpoint = Cassette { endpoint = endpoint, apiCalls = [], ignoredHeaders = [], ignoredBodyFields = [] }
 
+-- utility methods for matching with ignored fields in the body
+
+-- | Remove the ignored fields from the request's body
+modifyBody :: [Text] -> SavedRequest -> SavedRequest
+modifyBody ignoredBodyFields (SavedRequest mn hs url ps body) = SavedRequest mn hs url ps body'
+  where ignoredBodyFieldsMap = HashMap.fromList $ zip ignoredBodyFields (repeat Null)
+        bodyMap :: HashMap Text Value = HashMap.difference (fromJust . decode $ L.fromStrict body) ignoredBodyFieldsMap
+        body' = L.toStrict $ encode bodyMap
+
+-- | Remove the ignored fields from all of the saved requests
+--   this allows us to later match the requests without the ignored fields taken into account.
+modifyCassette :: Cassette -> Cassette
+modifyCassette (Cassette endpoint apiCalls ignoredHeaders ignoredBodyFields) =
+  (Cassette endpoint apiCalls' ignoredHeaders ignoredBodyFields)
+  where
+    modifyApiCall ignoredBodyFields (ApiCall savedRequest savedResponse) = ApiCall (modifyBody ignoredBodyFields savedRequest) savedResponse
+    apiCalls' = (modifyApiCall ignoredBodyFields) <$> apiCalls
+
+-- | Read the cassette, removing the ignored fields from all saved requests' bodies
+readCassette :: String -> IO (Either ParseException Cassette)
+readCassette filePath = do
+  cassette <- decodeFileEither filePath
+  pure (modifyCassette <$> cassette)


### PR DESCRIPTION
So this is perhaps not the most elegant way of doing that (i.e. the bodies are decoded to a HashMap, the ignored fields are removed and they are decoded back to a bytestring) but it's one that I could do in finite time 😏 

A thing to consider for the future is the ability to ignore nested fields. Also, this PR uses `fromJust` in a few places, I'll think  of an elegant way of replacing it with something safer.