### PR TITLE
Improve UX by comparing/storing JSON, show diff between values

### DIFF
--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -1,0 +1,10 @@
+indentation: 2
+comma-style: leading
+import-export-style: leading
+indent-wheres: true
+record-brace-space: true
+diff-friendly-import-export: true
+respectful: true
+haddock-style: multi-line
+newlines-between-decls: 1
+fixities: []

--- a/package.yaml
+++ b/package.yaml
@@ -37,6 +37,8 @@ dependencies:
 - warp
 - wai
 - aeson
+- aeson-pretty
+- aeson-diff
 - yaml
 - uri-bytestring
 - optparse-applicative

--- a/src/Network/VCR.hs
+++ b/src/Network/VCR.hs
@@ -1,107 +1,126 @@
 {-# LANGUAGE NamedFieldPuns #-}
-module Network.VCR
-    ( server
-    , withServer
-    ) where
 
-import           Control.Concurrent         (forkIO, killThread, threadDelay)
-import           Control.Concurrent.MVar    (MVar, newEmptyMVar, putMVar,
-                                             takeMVar)
-import           Control.Exception          (SomeException, bracket)
+module Network.VCR (
+    server,
+    withServer,
+) where
 
-import           Control.Monad
-import qualified Data.ByteString.Char8      as BS
+import Control.Concurrent (forkIO, killThread, threadDelay)
+import Control.Concurrent.MVar (
+    MVar,
+    newEmptyMVar,
+    putMVar,
+    takeMVar,
+ )
+import Control.Exception (SomeException, bracket)
+
+import Control.Monad
+import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Lazy.Char8 as LBS
-import           Data.IORef                 (IORef, newIORef)
-import qualified Data.Text                  as T
-import qualified Network.HTTP.Client        as HC
-import qualified Network.HTTP.Conduit       as HC
-import qualified Network.HTTP.Proxy         as HProxy (Request (..),
-                                                       Settings (..),
-                                                       defaultProxySettings,
-                                                       httpProxyApp)
-import qualified Network.HTTP.Types         as HT
-import qualified Network.Wai                as Wai
-import qualified Network.Wai.Handler.Warp   as Warp
+import Data.IORef (IORef, newIORef)
+import qualified Data.Text as T
+import qualified Network.HTTP.Client as HC
+import qualified Network.HTTP.Conduit as HC
+import qualified Network.HTTP.Proxy as HProxy (
+    Request (..),
+    Settings (..),
+    defaultProxySettings,
+    httpProxyApp,
+ )
+import qualified Network.HTTP.Types as HT
+import qualified Network.Wai as Wai
+import qualified Network.Wai.Handler.Warp as Warp
 
+import Control.Applicative ((<**>))
+import Network.VCR.Middleware (die, middleware)
+import Network.VCR.Types (
+    Cassette,
+    Mode (..),
+    Options (..),
+    emptyCassette,
+    parseOptions,
+ )
+import Options.Applicative (
+    execParser,
+    fullDesc,
+    header,
+    helper,
+    info,
+    progDesc,
+ )
+import System.Environment (getArgs)
 
-import           Control.Applicative        ((<**>))
-import           Network.VCR.Middleware     (die, middleware)
-import           Network.VCR.Types          (Cassette, Mode (..), Options (..),
-                                             emptyCassette, parseOptions)
-import           Options.Applicative        (execParser, fullDesc, header,
-                                             helper, info, progDesc)
-import           System.Environment         (getArgs)
-
-import           Data.Yaml                  (decodeFileEither, encodeFile)
-import           System.Directory           (doesFileExist)
-import           System.IO                  (BufferMode (..), hSetBuffering,
-                                             stdout)
-
+import Data.Yaml (decodeFileEither, encodeFile)
+import System.Directory (doesFileExist)
+import System.IO (
+    BufferMode (..),
+    hSetBuffering,
+    stdout,
+ )
 
 server :: IO ()
 server = execParser opts >>= run
   where
-    opts = info (parseOptions <**> helper)
-      ( fullDesc
-     <> progDesc "Run the VCR proxy to replay or record API calls. Runs in replay mode by default."
-     <> header "VCR Proxy" )
+    opts =
+        info
+            (parseOptions <**> helper)
+            ( fullDesc
+                <> progDesc "Run the VCR proxy to replay or record API calls. Runs in replay mode by default."
+                <> header "VCR Proxy"
+            )
 
 run :: Options -> IO ()
 run options = withServer options $ do
-  forever $ threadDelay 1000000000
-
+    forever $ threadDelay 1000000000
 
 withServer :: Options -> IO a -> IO a
-withServer options@Options { mode, cassettePath, port } action = do
-  putStrLn $ "Starting VCR proxy, mode: " <> show mode  <> ", cassette file: " <> cassettePath <>  ", listening on port: " <> show port
-  case mode of
-    Record endpoint -> do
-      exists <- doesFileExist cassettePath
-      when (not exists) $ encodeFile cassettePath (emptyCassette $ T.pack endpoint)
-    _ -> pure ()
-  cas <- decodeFileEither cassettePath
-  case cas of
-    Left  err -> die $ "Cassette: " <> cassettePath <> " couldn't be decoded or found! " <> (show err)
-    Right cassette -> do
-      cassetteIORef <- newIORef cassette
-      runInternal options cassetteIORef $ do
-        putStrLn "VCR proxy started"
-        action
+withServer options@Options{mode, cassettePath, port} action = do
+    putStrLn $ "Starting VCR proxy, mode: " <> show mode <> ", cassette file: " <> cassettePath <> ", listening on port: " <> show port
+    case mode of
+        Record endpoint -> do
+            exists <- doesFileExist cassettePath
+            when (not exists) $ encodeFile cassettePath (emptyCassette $ T.pack endpoint)
+        _ -> pure ()
+    cas <- decodeFileEither cassettePath
+    case cas of
+        Left err -> die $ "Cassette: " <> cassettePath <> " couldn't be decoded or found! " <> (show err)
+        Right cassette -> do
+            cassetteIORef <- newIORef cassette
+            runInternal options cassetteIORef $ do
+                putStrLn "VCR proxy started"
+                action
 
 runInternal :: Options -> IORef Cassette -> IO a -> IO a
-runInternal Options { mode, cassettePath, port } cassetteIORef action = do
-  -- Set line buffering, because if we use it from a parent process, pipes are full buffered by default
-  hSetBuffering stdout LineBuffering
-  started <- newEmptyMVar
-  bracket (start started) killThread $ \_ -> do
-    takeMVar started
-    action
-
+runInternal Options{mode, cassettePath, port} cassetteIORef action = do
+    -- Set line buffering, because if we use it from a parent process, pipes are full buffered by default
+    hSetBuffering stdout LineBuffering
+    started <- newEmptyMVar
+    bracket (start started) killThread $ \_ -> do
+        takeMVar started
+        action
   where
     start started = forkIO $ do
-      mgr <- HC.newManager HC.tlsManagerSettings
-      Warp.runSettings (warpSettings started proxySettings) $ middleware mode cassetteIORef cassettePath $ HProxy.httpProxyApp proxySettings mgr
-    proxySettings = HProxy.defaultProxySettings { HProxy.proxyPort = port }
+        mgr <- HC.newManager HC.tlsManagerSettings
+        Warp.runSettings (warpSettings started proxySettings) $ middleware mode cassetteIORef cassettePath $ HProxy.httpProxyApp proxySettings mgr
+    proxySettings = HProxy.defaultProxySettings{HProxy.proxyPort = port}
 
-
-
-warpSettings
-  :: MVar () -- ^ MVar to put after starting
-  -> HProxy.Settings
-  -> Warp.Settings
-warpSettings started pset = Warp.setPort (HProxy.proxyPort pset)
-    . Warp.setHost (HProxy.proxyHost pset)
-    . Warp.setTimeout (HProxy.proxyTimeout pset)
-    . Warp.setOnExceptionResponse defaultExceptionResponse
-    -- This is needed so we know when we start using the proxy if it is run as a child process
-    . Warp.setBeforeMainLoop (putMVar started ())
-    $ Warp.setNoParsePath True Warp.defaultSettings
+warpSettings ::
+    -- | MVar to put after starting
+    MVar () ->
+    HProxy.Settings ->
+    Warp.Settings
+warpSettings started pset =
+    Warp.setPort (HProxy.proxyPort pset)
+        . Warp.setHost (HProxy.proxyHost pset)
+        . Warp.setTimeout (HProxy.proxyTimeout pset)
+        . Warp.setOnExceptionResponse defaultExceptionResponse
+        -- This is needed so we know when we start using the proxy if it is run as a child process
+        . Warp.setBeforeMainLoop (putMVar started ())
+        $ Warp.setNoParsePath True Warp.defaultSettings
 
 defaultExceptionResponse :: SomeException -> Wai.Response
 defaultExceptionResponse e =
-        Wai.responseLBS HT.badGateway502
-                [ (HT.hContentType, "text/plain; charset=utf-8") ]
-                $ LBS.fromChunks [BS.pack $ show e]
-
-
+    Wai.responseLBS
+        HT.badGateway502
+        [(HT.hContentType, "text/plain; charset=utf-8")]
+        $ LBS.fromChunks [BS.pack $ show e]

--- a/src/Network/VCR/Middleware.hs
+++ b/src/Network/VCR/Middleware.hs
@@ -1,56 +1,77 @@
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
+
 module Network.VCR.Middleware where
 
-
-import           Control.Monad              (when)
-import           Data.ByteString.Builder    (toLazyByteString)
-import qualified Data.ByteString.Char8      as BS
+import Control.Monad (when)
+import Data.ByteString.Builder (toLazyByteString)
+import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Lazy.Char8 as LBS
-import           Data.IORef                 (IORef, modifyIORef', newIORef,
-                                             readIORef, writeIORef)
-import           Data.List                  (find)
-import           Data.Maybe                 (mapMaybe)
-import           Data.Text                  (Text)
-import qualified Data.Text                  as T
+import Data.IORef (
+  IORef,
+  modifyIORef',
+  newIORef,
+  readIORef,
+  writeIORef,
+ )
+import Data.List (find)
+import Data.Maybe (mapMaybe)
+import Data.Text (Text)
+import qualified Data.Text as T
 
-import qualified Data.Text.Encoding         as TE
+import qualified Data.Text.Encoding as TE
 
-import           Data.Yaml                  (decodeFileEither, encode,
-                                             encodeFile)
-import qualified Network.HTTP.Types         as HT
-import           Network.VCR.Types          (ApiCall (..), Cassette (..),
-                                             Mode (..), SavedRequest (..),
-                                             SavedResponse (..), emptyCassette)
-import qualified Network.Wai                as Wai
+import Data.Yaml (
+  decodeFileEither,
+  encode,
+  encodeFile,
+ )
+import qualified Network.HTTP.Types as HT
+import Network.VCR.Types (
+  ApiCall (..),
+  Body (..),
+  Cassette (..),
+  Mode (..),
+  ReplayError (..),
+  SavedRequest (..),
+  SavedResponse (..),
+  VCRResponse (..),
+  bodyToLBS,
+  emptyCassette,
+  lbsToBody,
+ )
+import qualified Network.Wai as Wai
 
-import           Data.CaseInsensitive       (mk)
-import qualified Data.Text.Encoding         as BE (encodeUtf8)
+import qualified Data.Text.Encoding as BE (encodeUtf8)
 
-import qualified Codec.Compression.GZip     as GZip
-import           Data.CaseInsensitive       (CI)
-import           Data.IORef                 (atomicModifyIORef)
-import qualified System.Exit                as XIO
-import           System.IO                  (stderr)
-import qualified System.IO                  (hPutStrLn)
-import qualified URI.ByteString             as URI
+import qualified Codec.Compression.GZip as GZip
+import qualified Data.Aeson as A
+import qualified Data.Aeson.Diff as A
+import qualified Data.Aeson.Encode.Pretty as A
+
+import Data.CaseInsensitive (CI, mk)
+import Data.IORef (atomicModifyIORef)
+import qualified System.Exit as XIO
+import System.IO (stderr)
+import qualified System.IO (hPutStrLn)
+import qualified URI.ByteString as URI
 
 middleware :: Mode -> IORef Cassette -> FilePath -> Wai.Middleware
-middleware Replay              = replayingMiddleware findAnyResponse
-middleware ReplayStrict        = replayingMiddleware consumeRequestsInOrder
-middleware Record { endpoint } = recordingMiddleware endpoint
+middleware Replay = replayingMiddleware findAnyResponse
+middleware ReplayStrict = replayingMiddleware consumeRequestsInOrder
+middleware Record {endpoint} = recordingMiddleware endpoint
 
-
--- | Middleware which only records API calls, the requests are proxied to the `endpoint` and recorded in the
--- `filePath` cassette file
+{- | Middleware which only records API calls, the requests are proxied to the `endpoint` and recorded in the
+ `filePath` cassette file
+-}
 recordingMiddleware :: String -> IORef Cassette -> FilePath -> Wai.Middleware
 recordingMiddleware endpoint cassetteIORef filePath app req respond = do
-  cassette@Cassette { apiCalls, ignoredHeaders }<- readIORef cassetteIORef
+  cassette@Cassette {apiCalls, ignoredHeaders} <- readIORef cassetteIORef
   (req', body) <- getRequestBody req
   -- Construct a request that can be sent to the actual remote API, by replacing the host in the request with the endpoint
   -- passed as an argument to the middleware
-  let newRequest = (modifyEndpoint (T.pack endpoint) req')
+  let newRequest = modifyEndpoint (T.pack endpoint) req'
   -- delegate to http-proxy app
   app newRequest $ \response -> do
     -- Save the request that we have received from the remote API
@@ -59,106 +80,120 @@ recordingMiddleware endpoint cassetteIORef filePath app req respond = do
     (status, headers, reBody) <- getResponseBody response
     savedResponse <- buildResponse reBody response
     -- Store the request, response pair
-    encodeFile filePath $ cassette
-      { apiCalls = apiCalls <> [ApiCall { request = savedRequest, response = savedResponse }] }
+    encodeFile filePath $
+      cassette
+        { apiCalls = apiCalls <> [ApiCall {request = savedRequest, response = savedResponse}]
+        }
     respond $ Wai.responseLBS status headers (gzipIfNeeded headers reBody)
 
-
 -- | A policy for obtaining responses given a request.
-type FindResponse = IORef Cassette -> SavedRequest -> IO (Either Text SavedResponse)
+type FindResponse = IORef Cassette -> SavedRequest -> IO (Either ReplayError SavedResponse)
 
 findAnyResponse :: FindResponse
 findAnyResponse cassetteIORef savedRequest = do
-  Cassette { apiCalls, ignoredHeaders } <- readIORef cassetteIORef
+  Cassette {apiCalls, ignoredHeaders} <- readIORef cassetteIORef
   pure $
     fmap response $
-    note ("The request: " <> tshow savedRequest <> " is not recorded! Ignored headers: " <> tshow ignoredHeaders) $
-    find (\c -> request c == savedRequest) apiCalls
+      note RequestNotRecorded $
+        find (\c -> request c == savedRequest) apiCalls
 
 -- | A policy for obtaining response which expects the request to be issued in the order they were recorded.
 consumeRequestsInOrder :: FindResponse
 consumeRequestsInOrder cassetteIORef savedRequest = do
-  cassette@Cassette { apiCalls, ignoredHeaders } <- readIORef cassetteIORef
+  cassette@Cassette {apiCalls, ignoredHeaders} <- readIORef cassetteIORef
   case apiCalls of
     c : rest -> do
-      if request c == savedRequest then do
-        writeIORef cassetteIORef $ cassette { apiCalls = rest }
-        pure $ Right $ response c
-      else
-        pure $ Left $ "Expected a different request: " <> tshow savedRequest
+      if request c == savedRequest
+        then do
+          writeIORef cassetteIORef $ cassette {apiCalls = rest}
+          pure $ Right $ response c
+        else pure $ Left $ ExpectedDifferentRequest (request c)
     [] ->
-      pure $ Left "No more requests recorded!"
+      pure $ Left RequestNotRecorded
 
--- | Middleware which only replays API calls, if a request is not found in the filePath provided cassette file,
--- a 500 error will be thrown
+{- | Middleware which only replays API calls, if a request is not found in the filePath provided cassette file,
+ a 500 error will be thrown
+-}
 replayingMiddleware :: FindResponse -> IORef Cassette -> FilePath -> Wai.Middleware
 replayingMiddleware findResponse cassetteIORef filePath app req respond = do
-  cassette@Cassette { apiCalls, ignoredHeaders } <- readIORef cassetteIORef
+  cassette@Cassette {apiCalls, ignoredHeaders} <- readIORef cassetteIORef
   b <- Wai.strictRequestBody req
-  let savedRequest = buildRequest ignoredHeaders req b
+  let receivedRequest = buildRequest ignoredHeaders req b
   -- Find an existing ApiCall according to the FindResponse policy
-  findResponse cassetteIORef savedRequest >>= \case
+  findResponse cassetteIORef receivedRequest >>= \case
     -- if a request is found, respond with the saved response
     Right res -> do
-      let
-        gzippedBody = gzipIfNeeded (headers (res :: SavedResponse)) (body (res :: SavedResponse))
-      respond $ Wai.responseLBS (status res) (headers (res :: SavedResponse)) (gzippedBody)
+      let gzippedBody = gzipIfNeeded (headers (res :: SavedResponse)) (bodyToLBS $ body (res :: SavedResponse))
+      respond $ Wai.responseLBS (status res) (headers (res :: SavedResponse)) gzippedBody
     -- if the request was not recorded, return an error
-    Left msg -> do
-      let msg' = TE.encodeUtf8 msg
-      respond $ Wai.responseLBS HT.status500 { HT.statusMessage = msg' } [] (LBS.fromStrict $ msg' <> " YAML:" <> encode savedRequest)
-
+    Left err -> do
+      let (msg, savedRequest) = case err of
+            RequestNotRecorded -> ("Request not recorded", Nothing)
+            ExpectedDifferentRequest expected -> ("Expected a different request", Just expected)
+          diff = A.diff (A.toJSON receivedRequest) . A.toJSON <$> savedRequest
+          response = VCRResponse {_error = msg, _receivedRequest = receivedRequest, _expectedRequest = savedRequest, _diff = diff}
+      putTextStdErrLn $
+        "\ESC[31mVCRProxy error: "
+          <> msg
+          <> "\ESC[0mExpected request (only in strict replay mode): \n\ESC[34m"
+          <> jsonToText (A.toJSON savedRequest)
+          <> "\ESC[0mReceived request: \n"
+          <> jsonToText (A.toJSON receivedRequest)
+          <> "\ESC[33mDiff: \n"
+          <> jsonToText (A.toJSON diff)
+      respond $ Wai.responseLBS HT.status500 [] (A.encode response)
 
 -- | Modify parts of the request so that it can be sent to the remote API while being received on a localhost server
 modifyEndpoint :: Text -> Wai.Request -> Wai.Request
-modifyEndpoint endpoint req = req
-  { Wai.requestHeaderHost = Just host
-  , Wai.rawPathInfo       = modifyPath $ Wai.rawPathInfo req
-  , Wai.requestHeaders    = mapMaybe modifyHeader (Wai.requestHeaders req) <> [("accept-encoding", "identity")]
-  } where
-    endpoint'                   = TE.encodeUtf8 endpoint
-    uri                         = either endpointError id $ URI.parseURI URI.strictURIParserOptions endpoint'
-    host                        = maybe noHostError (URI.hostBS . URI.authorityHost) (URI.uriAuthority uri)
-    scheme                      = URI.schemeBS . URI.uriScheme $ uri
+modifyEndpoint endpoint req =
+  req
+    { Wai.requestHeaderHost = Just host
+    , Wai.rawPathInfo = modifyPath $ Wai.rawPathInfo req
+    , Wai.requestHeaders = mapMaybe modifyHeader (Wai.requestHeaders req) <> [("accept-encoding", "identity")]
+    }
+  where
+    endpoint' = TE.encodeUtf8 endpoint
+    uri = either endpointError id $ URI.parseURI URI.strictURIParserOptions endpoint'
+    host = maybe noHostError (URI.hostBS . URI.authorityHost) (URI.uriAuthority uri)
+    scheme = URI.schemeBS . URI.uriScheme $ uri
     modifyHeader h@(key, value)
-      | key == mk "host"             = Just (key, host)
-      | key == mk "accept-encoding"  = Nothing
-      | otherwise                 = Just h
-    modifyPath                  = BS.append scheme . BS.append "://" . BS.append host
-    endpointError e             = error $ "Error parsing endpoint as URI, " <> show e
-    noHostError                 = error "No host could be extracted from the endpoint"
+      | key == mk "host" = Just (key, host)
+      | key == mk "accept-encoding" = Nothing
+      | otherwise = Just h
+    modifyPath = BS.append scheme . BS.append "://" . BS.append host
+    endpointError e = error $ "Error parsing endpoint as URI, " <> show e
+    noHostError = error "No host could be extracted from the endpoint"
 
 buildRequest :: [Text] -> Wai.Request -> LBS.ByteString -> SavedRequest
 buildRequest ignoredHeaders r body =
   SavedRequest
-    { methodName              = TE.decodeUtf8 $ Wai.requestMethod r
-    , headers                 = reqHeaders
-    , url                     = TE.decodeUtf8 $ Wai.rawPathInfo r
-    , params                  = Wai.queryString r
-    , body                    = LBS.toStrict body
+    { methodName = TE.decodeUtf8 $ Wai.requestMethod r
+    , headers = reqHeaders
+    , url = TE.decodeUtf8 $ Wai.rawPathInfo r
+    , params = Wai.queryString r
+    , body = lbsToBody body
     }
   where
-    reqHeaders                = filter (\(key, value) -> elem key ignoredHeaders')  (Wai.requestHeaders r)
-    ignoredHeaders'           = mk . BE.encodeUtf8 <$> ignoredHeaders
+    reqHeaders = filter (\(key, value) -> key `elem` ignoredHeaders') (Wai.requestHeaders r)
+    ignoredHeaders' = mk . BE.encodeUtf8 <$> ignoredHeaders
 
 buildResponse :: LBS.ByteString -> Wai.Response -> IO SavedResponse
 buildResponse body response = do
-  pure $ SavedResponse
-    { body                  = body
-    , headers               = Wai.responseHeaders response
-    , status                = Wai.responseStatus response
-    }
+  pure $
+    SavedResponse
+      { body = lbsToBody body
+      , headers = Wai.responseHeaders response
+      , status = Wai.responseStatus response
+      }
 
 getResponseBody :: Wai.Response -> IO (HT.Status, HT.ResponseHeaders, LBS.ByteString)
 getResponseBody res =
-  let (status,headers,body) = Wai.responseToStream res in
-  body $ \f -> do
-    content <- newIORef mempty
-    f (\chunk -> modifyIORef' content (<> chunk)) (return ())
-    b <- toLazyByteString <$> readIORef content
-    pure (status, headers, b)
-
-
+  let (status, headers, body) = Wai.responseToStream res
+   in body $ \f -> do
+        content <- newIORef mempty
+        f (\chunk -> modifyIORef' content (<> chunk)) (return ())
+        b <- toLazyByteString <$> readIORef content
+        pure (status, headers, b)
 
 -- Taken from: https://github.com/yesodweb/wai/blob/master/wai-extra/Network/Wai/Middleware/RequestLogger.hs#L220
 getRequestBody :: Wai.Request -> IO (Wai.Request, [BS.ByteString])
@@ -166,43 +201,50 @@ getRequestBody req = do
   let loop front = do
         bs <- Wai.requestBody req
         if BS.null bs
-            then return $ front []
-            else loop $ front . (bs:)
+          then return $ front []
+          else loop $ front . (bs :)
   body <- loop id
   -- Since reading the body consumes it, we need to refill it.
   -- This implementation ensures that each chunk is only returned
   -- once.
   ichunks <- newIORef body
   let rbody = atomicModifyIORef ichunks $ \chunks ->
-         case chunks of
-             []  -> ([], BS.empty)
-             x:y -> (y, x)
+        case chunks of
+          [] -> ([], BS.empty)
+          x : y -> (y, x)
   -- This triggers a deprecation warning, that makes no sense in this case, since there is no other way to reset the
   -- request body
-  let req' = req { Wai.requestBody = rbody }
+  let req' = req {Wai.requestBody = rbody}
   return (req', body)
-
 
 die :: String -> IO a
 die err = (System.IO.hPutStrLn stderr err) >> XIO.exitFailure
 
-
 gzipIfNeeded :: [HT.Header] -> LBS.ByteString -> LBS.ByteString
 gzipIfNeeded headers body | needsCompression headers = GZip.compress body
-gzipIfNeeded _ body       = body
+gzipIfNeeded _ body = body
 
 needsCompression :: [HT.Header] -> Bool
 needsCompression headers =
   case lookup ("Content-Encoding" :: CI BS.ByteString) headers of
     Just "gzip" -> True
-    _           -> False
+    _ -> False
 
 safeHead :: [a] -> Maybe a
-safeHead []    = Nothing
-safeHead (x:_) = Just x
+safeHead [] = Nothing
+safeHead (x : _) = Just x
 
 note :: e -> Maybe a -> Either e a
 note err = maybe (Left err) Right
 
 tshow :: Show a => a -> Text
 tshow = T.pack . show
+
+putTextStdErrLn :: Text -> IO ()
+putTextStdErrLn = System.IO.hPutStrLn stderr . T.unpack
+
+lsbToText :: LBS.ByteString -> T.Text
+lsbToText = TE.decodeUtf8 . LBS.toStrict
+
+jsonToText :: A.Value -> T.Text
+jsonToText = lsbToText . A.encodePretty

--- a/src/Network/VCR/Middleware.hs
+++ b/src/Network/VCR/Middleware.hs
@@ -135,11 +135,11 @@ replayingMiddleware findResponse cassetteIORef filePath app req respond = do
       putTextStdErrLn $
         "\ESC[31mVCRProxy error: "
           <> msg
-          <> "\ESC[0mExpected request (only in strict replay mode): \n\ESC[34m"
+          <> "\n\ESC[0mExpected request (only in strict replay mode): \n\ESC[34m"
           <> jsonToText (A.toJSON savedRequest)
-          <> "\ESC[0mReceived request: \n"
+          <> "\n\ESC[0mReceived request: \n"
           <> jsonToText (A.toJSON receivedRequest)
-          <> "\ESC[33mDiff: \n"
+          <> "\n\ESC[33mDiff: \n"
           <> jsonToText (A.toJSON diff)
       respond $ Wai.responseLBS HT.status500 [] (A.encode response)
 

--- a/src/Network/VCR/Types.hs
+++ b/src/Network/VCR/Types.hs
@@ -1,130 +1,193 @@
-{-# LANGUAGE DeriveAnyClass  #-}
-{-# LANGUAGE DeriveGeneric   #-}
-{-# LANGUAGE NamedFieldPuns  #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE PatternSynonyms #-}
+
 module Network.VCR.Types where
 
-import qualified Data.ByteString         as B
-import qualified Data.ByteString.Lazy    as L
-import           Data.Text               (Text)
-import qualified Data.Text.Encoding      as BE (decodeUtf8, encodeUtf8)
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Lazy as L
+import Data.Text (Text)
+import qualified Data.Text.Encoding as BE (decodeUtf8, encodeUtf8)
 import qualified Data.Text.Lazy.Encoding as BEL (decodeUtf8, encodeUtf8)
 
+import Control.Monad (mzero)
+import Data.Aeson (
+  FromJSON,
+  ToJSON,
+  Value (..),
+  decode,
+  decodeStrict,
+  encode,
+  object,
+  parseJSON,
+  toJSON,
+  (.:),
+  (.=),
+ )
+import Data.Aeson.Diff (Patch)
+import Data.CaseInsensitive (foldedCase, mk)
+import GHC.Generics (Generic)
 
-import           Control.Monad           (mzero)
-import           Data.Aeson              (FromJSON, ToJSON, Value (..), object,
-                                          parseJSON, toJSON, (.:), (.=))
-import           Data.CaseInsensitive    (foldedCase, mk)
-import           GHC.Generics            (Generic)
+import Network.HTTP.Types (Header, Query, Status (..))
 
-import           Network.HTTP.Types      (Header, Query, Status (..))
+import Control.Applicative ((<|>))
+import Data.Semigroup ((<>))
+import Options.Applicative (
+  Parser,
+  auto,
+  help,
+  long,
+  metavar,
+  option,
+  short,
+  showDefault,
+  strOption,
+  value,
+ )
 
-import           Control.Applicative     ((<|>))
-import           Data.Semigroup          ((<>))
-import           Options.Applicative     (Parser, auto, help, long, metavar,
-                                          option, short, showDefault, strOption,
-                                          value)
-
-
-data Mode = Record { endpoint :: String } | Replay | ReplayStrict
+data Mode = Record {endpoint :: String} | Replay | ReplayStrict
   deriving (Show, Eq)
 
+data ReplayError = RequestNotRecorded | ExpectedDifferentRequest SavedRequest
+
+data VCRResponse = VCRResponse {_error :: Text, _receivedRequest :: SavedRequest, _expectedRequest :: Maybe SavedRequest, _diff :: Maybe Patch}
+  deriving (Show, Eq, Generic)
+
+instance ToJSON VCRResponse where
+  toJSON VCRResponse {_error, _receivedRequest, _expectedRequest} =
+    object
+      [ "error" .= _error
+      , "receivedRequest" .= toJSON _receivedRequest
+      , "expectedRequest" .= toJSON _expectedRequest
+      , "tag" .= ("VCRResponse" :: Text)
+      ]
 
 parseMode :: Parser Mode
 parseMode =
-  (\mode endpoint ->
-    case mode of
-      "Record"       -> Record endpoint
-      "Replay"       -> Replay
-      "ReplayStrict" -> ReplayStrict
-      m              -> error $ "Uknown mode: " <> m
-  ) <$> strOption ( long "mode" <> short 'm' <> metavar "MODE" <> help "Run vcr proxy in the specified mode: Record | Replay | ReplayStrict")
-    <*> strOption ( long "endpoint" <> short 'e' <> metavar "REMOTE_API_ENDPOINT" <> help "Forward requests to the specified API endpoint")
+  ( \mode endpoint ->
+      case mode of
+        "Record" -> Record endpoint
+        "Replay" -> Replay
+        "ReplayStrict" -> ReplayStrict
+        m -> error $ "Uknown mode: " <> m
+  )
+    <$> strOption (long "mode" <> short 'm' <> metavar "MODE" <> help "Run vcr proxy in the specified mode: Record | Replay | ReplayStrict")
+    <*> strOption (long "endpoint" <> short 'e' <> metavar "REMOTE_API_ENDPOINT" <> help "Forward requests to the specified API endpoint")
 
 data Options = Options
   { cassettePath :: FilePath
-  , mode         :: Mode
-  , port         :: Int
-  } deriving (Eq, Show)
+  , mode :: Mode
+  , port :: Int
+  }
+  deriving (Eq, Show)
 
 pattern DEFAULT_PORT :: Int
 pattern DEFAULT_PORT = 3128
 
 parseOptions :: Parser Options
-parseOptions = Options
-  <$> strOption (long "cassette" <> short 'c' <> metavar "CASSETTE_FILE" <> help "Cassette yaml file for recording/replaying the API interactions")
-  <*> parseMode
-  <*> option auto (long "port" <> help "Port to listen on" <> showDefault <> value DEFAULT_PORT <> metavar "INT")
+parseOptions =
+  Options
+    <$> strOption (long "cassette" <> short 'c' <> metavar "CASSETTE_FILE" <> help "Cassette yaml file for recording/replaying the API interactions")
+    <*> parseMode
+    <*> option auto (long "port" <> help "Port to listen on" <> showDefault <> value DEFAULT_PORT <> metavar "INT")
 
+data Body = JSONBody Value | RawBody B.ByteString
+  deriving (Show, Eq)
+
+bodyToLBS :: Body -> L.ByteString
+bodyToLBS (RawBody bs) = L.fromStrict bs
+bodyToLBS (JSONBody value) = encode value
+
+lbsToBody :: L.ByteString -> Body
+lbsToBody = bsToBody . L.toStrict
+
+bsToBody :: B.ByteString -> Body
+bsToBody body = maybe (RawBody body) JSONBody (decodeStrict body)
+
+instance FromJSON Body where
+  parseJSON v@(Object _) = pure $ JSONBody v
+  parseJSON (String s) =
+    -- Try extra hard to parse the body as JSON (for backwards compatibility with "stringified" JSON requests)
+    pure $ bsToBody (BE.encodeUtf8 s)
+
+instance ToJSON Body where
+  toJSON (JSONBody b) = b
+  toJSON (RawBody b) = toJSON (BE.decodeUtf8 b)
 
 data SavedRequest = SavedRequest
   { methodName :: Text
-  , headers    :: [Header]
-  , url        :: Text
-  , params     :: Query
-  , body       :: B.ByteString
-  } deriving (Show, Eq)
-
+  , headers :: [Header]
+  , url :: Text
+  , params :: Query
+  , body :: Body
+  }
+  deriving (Show, Eq)
 
 data ApiCall = ApiCall
-  { request  :: SavedRequest
+  { request :: SavedRequest
   , response :: SavedResponse
-  } deriving (Show, Eq, Generic, ToJSON, FromJSON)
+  }
+  deriving (Show, Eq, Generic, ToJSON, FromJSON)
 
 data Cassette = Cassette
-  { endpoint       :: Text
-  , apiCalls       :: [ApiCall]
+  { endpoint :: Text
+  , apiCalls :: [ApiCall]
   , ignoredHeaders :: [Text]
-  } deriving (Show, Eq, Generic, ToJSON, FromJSON)
-
+  }
+  deriving (Show, Eq, Generic, ToJSON, FromJSON)
 
 instance ToJSON SavedRequest where
-  toJSON (SavedRequest{ methodName, headers, url, params , body}) =
+  toJSON (SavedRequest {methodName, headers, url, params, body}) =
     object
       [ "methodName" .= methodName
-      , "headers"    .= toJSON (fromHeader <$> headers)
-      , "url"        .= url
-      , "params"     .= toJSON (fromQuery <$> params)
-      , "body"       .= BE.decodeUtf8 body
+      , "headers" .= toJSON (fromHeader <$> headers)
+      , "url" .= url
+      , "params" .= toJSON (fromQuery <$> params)
+      , "body" .= toJSON body
       ]
 
 instance FromJSON SavedRequest where
   parseJSON (Object v) =
-    SavedRequest <$>
-      v .: "methodName" <*>
-      ((\headers -> toHeader <$> headers) <$> (v .: "headers")) <*>
-      v .: "url"    <*>
-      ((\params -> toQuery <$> params) <$> v .: "params" ) <*>
-      (BE.encodeUtf8 <$> v .: "body")
-  parseJSON _          = mzero
+    SavedRequest
+      <$> v
+      .: "methodName"
+      <*> ((\headers -> toHeader <$> headers) <$> (v .: "headers"))
+      <*> v
+      .: "url"
+      <*> ((\params -> toQuery <$> params) <$> v .: "params")
+      <*> (v .: "body")
+  parseJSON _ = mzero
 
 data SavedResponse = SavedResponse
-  { body    :: L.ByteString
+  { body :: Body
   , headers :: [Header]
-  , status  :: Status
-  } deriving (Show, Eq)
+  , status :: Status
+  }
+  deriving (Show, Eq)
 
 instance ToJSON SavedResponse where
-  toJSON (SavedResponse { body, headers, status }) =
+  toJSON (SavedResponse {body, headers, status}) =
     object
-      [ "body"     .= (BEL.decodeUtf8 body)
-      , "headers"  .= toJSON (fromHeader <$> headers)
-      , "status"   .= object
-        [ "code"   .= statusCode status
-        , "message".= BE.decodeUtf8 (statusMessage status)
-        ]
+      [ "body" .= toJSON body
+      , "headers" .= toJSON (fromHeader <$> headers)
+      , "status"
+          .= object
+            [ "code" .= statusCode status
+            , "message" .= BE.decodeUtf8 (statusMessage status)
+            ]
       ]
 
 instance FromJSON SavedResponse where
-  parseJSON (Object v)         =
-    SavedResponse <$>
-      (BEL.encodeUtf8 <$> v .: "body") <*>
-      ((\headers -> toHeader <$> headers) <$> (v .: "headers")) <*>
-      ( v.: "status"         >>= parseStatus)
+  parseJSON (Object v) =
+    SavedResponse
+      <$> (v .: "body")
+      <*> ((\headers -> toHeader <$> headers) <$> (v .: "headers"))
+      <*> (v .: "status" >>= parseStatus)
     where
-      parseStatus (Object s)   = Status <$> (s .: "code") <*> (BE.encodeUtf8 <$> s .: "message")
-      parseStatus _            = mzero
-  parseJSON _                  = mzero
+      parseStatus (Object s) = Status <$> (s .: "code") <*> (BE.encodeUtf8 <$> s .: "message")
+      parseStatus _ = mzero
+  parseJSON _ = mzero
 
 fromQuery :: (B.ByteString, Maybe B.ByteString) -> (Text, Maybe Text)
 fromQuery (name, value) = (BE.decodeUtf8 name, BE.decodeUtf8 <$> value)
@@ -136,9 +199,7 @@ fromHeader :: Header -> (Text, Text)
 fromHeader (name, value) = (BE.decodeUtf8 $ foldedCase name, BE.decodeUtf8 value)
 
 toHeader :: (Text, Text) -> Header
-toHeader (name, value)  =  (mk $ BE.encodeUtf8 name, BE.encodeUtf8 value)
-
+toHeader (name, value) = (mk $ BE.encodeUtf8 name, BE.encodeUtf8 value)
 
 emptyCassette :: Text -> Cassette
-emptyCassette endpoint = Cassette { endpoint = endpoint, apiCalls = [], ignoredHeaders = [] }
-
+emptyCassette endpoint = Cassette {endpoint = endpoint, apiCalls = [], ignoredHeaders = []}

--- a/vcr-proxy.cabal
+++ b/vcr-proxy.cabal
@@ -38,6 +38,8 @@ library
       NamedFieldPuns
   build-depends:
       aeson
+    , aeson-diff
+    , aeson-pretty
     , base >=4.7 && <5
     , bytestring
     , bytestring-builder
@@ -69,6 +71,8 @@ executable vcr-proxy
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       aeson
+    , aeson-diff
+    , aeson-pretty
     , base >=4.7 && <5
     , bytestring
     , bytestring-builder
@@ -102,6 +106,8 @@ test-suite vcr-proxy-test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       aeson
+    , aeson-diff
+    , aeson-pretty
     , base >=4.7 && <5
     , bytestring
     , bytestring-builder


### PR DESCRIPTION
* Store/compare JSON instead of strings if body parses to JSON (field order won't matter) 
* Show debug info in Stderr (this is visible in Pendolino log) 
* Show a diff between expected / received request if we are in strict mode

Output: 

```
Starting process [{}, "vcr-proxy -c spec/fixtures/makeInvoiceForeign.yaml -m ReplayStrict -e https://api.infakt.pl"], pid: 74738
Starting process [{"INFAKT_INVOICING_ENDPOINT"=>"http://localhost:3128"}, "bin/restaumatic --config config/test.yaml server"], pid: 74750
Running on port 8082
GET /api/v1/server_version
  Accept: */*
  Status: 200 OK 0.004221886s
POST /api/v1/internal/rpc
  Request Body: {"id":"","method":"CreateChargesRequest","params":{"companyId":1,"adminUserId":1,"chargeData":[{"description":null,"net":10.28,"chargeAt":"2020-01-07","chargeType":"GprsPrinter","companyId":1,"recurring":false,"prepaid":false,"info":null}]}}
  Accept: */*
  Status: 200 OK 0.007461629s
VCRProxy error: Expected a different request
Expected request (only in strict replay mode):
{
    "methodName": "POST",
    "body": {
        "invoice": {
            "sale_type": "service",
            "swift": "WBKPPLPP",
            "bank_account": "PL63109020370000000130533457",
            "kind": "vat",
            "sale_date": "2020-01-08",
            "client_id": 8342621,
            "payment_date": "2020-01-14",
            "currency": "PLN",
            "invoice_date": "2020-01-07",
            "notes": " Odwrotne obciążenie / Reverse charge Restaumatic invoice id: 1",
            "bank_name": "Santander Bank Polska S.A.",
            "paid_price": 0,
            "services": [
                {
                    "gtu_id": null,
                    "tax_symbol": "0",
                    "tax_price": 0,
                    "unit_net_price_before_discount": 1028,
                    "gross_price": 1028,
                    "quantity": 1,
                    "symbol": "26.20.30",
                    "unit_net_price": 1028,
                    "name": "Drukarka GPRS",
                    "net_price": 1028,
                    "unit": ""
                }
            ]
        }
    },
    "url": "/v3/invoices.json",
    "params": [],
    "headers": []
}
Received request:
{
    "methodName": "POST",
    "body": {
        "invoice": {
            "sale_type": "service",
            "swift": "WBKPPLPP",
            "bank_account": "PL63109020370000000130533457",
            "kind": "vat",
            "sale_date": "2020-01-07",
            "client_id": 8342621,
            "payment_date": "2020-01-14",
            "currency": "PLN",
            "invoice_date": "2020-01-07",
            "notes": " Odwrotne obciążenie / Reverse charge Restaumatic invoice id: 1",
            "bank_name": "Santander Bank Polska S.A.",
            "paid_price": 0,
            "services": [
                {
                    "gtu_id": null,
                    "tax_symbol": "0",
                    "tax_price": 0,
                    "unit_net_price_before_discount": 1028,
                    "gross_price": 1028,
                    "quantity": 1,
                    "symbol": "26.20.30",
                    "unit_net_price": 1028,
                    "name": "Drukarka GPRS",
                    "net_price": 1028,
                    "unit": ""
                }
            ]
        }
    },
    "url": "/v3/invoices.json",
    "params": [],
    "headers": []
}
Diff:
[
    {
        "op": "replace",
        "path": "/body/invoice/sale_date",
        "value": "2020-01-08"
    }
]
POST /api/v1/internal/rpc
  Request Body: {"id":"","method":"CreateSettlementRequest","params":{"companyId":1,"invoiceData":{"companyId":1,"currency":"PLN","services":[],"invoiceDate":"2020-01-07","dueDate":"2020-01-14","number":"","note":null},"charges":[1],"adminUserId":1,"period":{"from":"2020-01-01T00:00:00.000000Z","to":"2020-01-07T23:59:59.999999Z"}}}
  Accept: */*
  Status: 200 OK 0.258167393s
Killing process 74750
Killing process 74738
F

Failures:

  1) Invoicing Form submission will include a reverse charge note for charges that require this
     Failure/Error: raise "VCRProxy error, see stderr for details."

     RuntimeError:
       VCRProxy error, see stderr for details.
     # ./spec/support/vcr_proxy.rb:22:in `rescue in with_vcr_proxy'
     # ./spec/support/vcr_proxy.rb:20:in `with_vcr_proxy'
     # ./spec-higgs/invoicing_spec.rb:68:in `block (3 levels) in <main>'
     # -e:1:in `<main>'
     # ------------------
     # --- Caused by: ---
     # RuntimeError:
     #   {"tag"=>"APIError", "contents"=>"API error, code: 500, message: \"{\\\"tag\\\":\\\"VCRResponse\\\",\\\"error\\\":\\\"Expected a different request\\\",\\\"expectedRequest\\\":{\\\"methodName\\\":\\\"POST\\\",\\\"body\\\":{\\\"invoice\\\":{\\\"sale_type\\\":\\\"service\\\",\\\"swift\\\":\\\"WBKPPLPP\\\",\\\"bank_account\\\":\\\"PL63109020370000000130533457\\\",\\\"kind\\\":\\\"vat\\\",\\\"sale_date\\\":\\\"2020-01-08\\\",\\\"client_id\\\":8342621,\\\"payment_date\\\":\\\"2020-01-14\\\",\\\"currency\\\":\\\"PLN\\\",\\\"invoice_date\\\":\\\"2020-01-07\\\",\\\"notes\\\":\\\" Odwrotne obci\\196\\133\\197\\188enie / Reverse charge Restaumatic invoice id: 1\\\",\\\"bank_name\\\":\\\"Santander Bank Polska S.A.\\\",\\\"paid_price\\\":0,\\\"services\\\":[{\\\"gtu_id\\\":null,\\\"tax_symbol\\\":\\\"0\\\",\\\"tax_price\\\":0,\\\"unit_net_price_before_discount\\\":1028,\\\"gross_price\\\":1028,\\\"quantity\\\":1,\\\"symbol\\\":\\\"26.20.30\\\",\\\"unit_net_price\\\":1028,\\\"name\\\":\\\"Drukarka GPRS\\\",\\\"net_price\\\":1028,\\\"unit\\\":\\\"\\\"}]}},\\\"url\\\":\\\"/v3/invoices.json\\\",\\\"params\\\":[],\\\"headers\\\":[]},\\\"receivedRequest\\\":{\\\"methodName\\\":\\\"POST\\\",\\\"body\\\":{\\\"invoice\\\":{\\\"sale_type\\\":\\\"service\\\",\\\"swift\\\":\\\"WBKPPLPP\\\",\\\"bank_account\\\":\\\"PL63109020370000000130533457\\\",\\\"kind\\\":\\\"vat\\\",\\\"sale_date\\\":\\\"2020-01-07\\\",\\\"client_id\\\":8342621,\\\"payment_date\\\":\\\"2020-01-14\\\",\\\"currency\\\":\\\"PLN\\\",\\\"invoice_date\\\":\\\"2020-01-07\\\",\\\"notes\\\":\\\" Odwrotne obci\\196\\133\\197\\188enie / Reverse charge Restaumatic invoice id: 1\\\",\\\"bank_name\\\":\\\"Santander Bank Polska S.A.\\\",\\\"paid_price\\\":0,\\\"services\\\":[{\\\"gtu_id\\\":null,\\\"tax_symbol\\\":\\\"0\\\",\\\"tax_price\\\":0,\\\"unit_net_price_before_discount\\\":1028,\\\"gross_price\\\":1028,\\\"quantity\\\":1,\\\"symbol\\\":\\\"26.20.30\\\",\\\"unit_net_price\\\":1028,\\\"name\\\":\\\"Drukarka GPRS\\\",\\\"net_price\\\":1028,\\\"unit\\\":\\\"\\\"}]}},\\\"url\\\":\\\"/v3/invoices.json\\\",\\\"params\\\":[],\\\"headers\\\":[]}}\"."}
     #   ./app/services/higgs_service.rb:573:in `either_to_error'

Finished in 43.49 seconds (files took 580 minutes 36 seconds to load)
7 examples, 1 failure
```